### PR TITLE
Add authentication setup and configuration details to README; create secrets.toml and .env.example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,33 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+## Configuration
+
+### Authentication Setup
+This application uses Auth0 for authentication. You need to configure your Auth0 credentials:
+
+1. Update file at `src/mvt/.streamlit/secrets.toml` with your Auth0 credentials:
+```
+[auth.auth0]
+client_id = "your_client_id"
+client_secret = "your_client_secret"
+domain = "your-domain.auth0.com"
+redirect_uri = "http://localhost:8501/callback"
+```
+
+You can find these credentials in your Auth0 dashboard at auth0.com after creating an application.
+
+### API Keys
+1. Rename the `.env.example` file in the `mvt` folder to `.env` and update it with your own credentials:
+```
+MISTRALAI_API_KEY =your_mistral_ai_api_key
+```
+
+2. (Optional) If you want to use Hugging Face API, add this to your `.env` file:
+```
+HF_TOKEN =your_huggingface_api_key
+```
+
 ## Test
 
 ```console

--- a/src/mvt/.env.example
+++ b/src/mvt/.env.example
@@ -1,0 +1,2 @@
+MISTRALAI_API_KEY = "provide your own key"
+HF_TOKEN = "provide your own key"

--- a/src/mvt/.streamlit/secrets.toml
+++ b/src/mvt/.streamlit/secrets.toml
@@ -1,0 +1,9 @@
+[auth]
+redirect_uri = "http://localhost:8501/oauth2callback"
+cookie_secret="set_a_cookkie_secret_here_any_random_cokkie"
+
+[auth.auth0]
+client_id = "your client_id"
+client_secret = "your client_secret"
+server_metadata_url = "https://{account}.{region}.auth0.com/.well-known/openid-configuration"
+client_kwargs = { "prompt" = "login" }

--- a/src/mvt/app.py
+++ b/src/mvt/app.py
@@ -7,7 +7,7 @@ from homepage import gethomepage
 st.markdown(body=gethomepage(), unsafe_allow_html=True)
 
 # Check if user is authenticated
-if not st.experimental_user.is_logged_in:
+if not st.user.is_logged_in:
     if st.button("Log in or Sign up"):
         st.login("auth0")
     st.stop()
@@ -26,22 +26,22 @@ if "username" not in st.session_state:
     st.session_state.username = None
 
 # Only access user info if available
-if hasattr(st.experimental_user, "email"):
+if hasattr(st.user, "email"):
     conn = create_connection()
     if conn is not None:
         create_table(conn)
 
         # Check if user exists
-        user_data = get_user(conn, st.experimental_user.email)
+        user_data = get_user(conn, st.user.email)
         if user_data is not None:
             st.session_state['user_type'] = user_data[3]
             st.session_state['username'] = user_data[1]
         else:
             user_type = 'guest'
-            username = st.experimental_user.email
+            username = st.user.email
             st.session_state['user_type'] = user_type
             st.session_state['username'] = username
-            insert_user(conn, username, st.experimental_user.email, user_type)
+            insert_user(conn, username, st.user.email, user_type)
 
 # Show menu
 menu()

--- a/src/mvt/main.py
+++ b/src/mvt/main.py
@@ -9,8 +9,6 @@ from langchain.chains import create_retrieval_chain
 from langchain_mistralai.embeddings import MistralAIEmbeddings
 
 def get_ragchain(filter):
-  
-
     # Read config data
     config_data = load_yaml_file("config.yaml")
 
@@ -18,36 +16,62 @@ def get_ragchain(filter):
 
     api_key = os.getenv("MISTRALAI_API_KEY")
 
-    # Define the embedding model
-    embeddings = MistralAIEmbeddings(model=config_data["embedding_model"], mistral_api_key=api_key)
-    
-    # Load local vector db
-    docsearch = FAISS.load_local(config_data["persist_directory"], embeddings, allow_dangerous_deserialization=True)
-
-    # Define a retriever interface
-    retriever = docsearch.as_retriever(search_type="mmr", search_kwargs={"k": 5, "filter": filter})
-
     # Define LLM
     model = ChatMistralAI(mistral_api_key=api_key, model=config_data["model_name"])
 
     # read prompt string from config file
     prompt_str = config_data["prompt"]
 
-    # Answer question
-    qa_system_prompt = (
-    prompt_str +
-    "\n\n"
-    "{context}"
-    )
+    # Check if FAISS directory exists
+    if os.path.exists(config_data["persist_directory"]):
+        try:
+            # Define the embedding model
+            embeddings = MistralAIEmbeddings(model=config_data["embedding_model"], mistral_api_key=api_key)
+            
+            # Load local vector db
+            docsearch = FAISS.load_local(config_data["persist_directory"], embeddings, allow_dangerous_deserialization=True)
 
-    qa_prompt = ChatPromptTemplate.from_messages(
+            # Define a retriever interface
+            retriever = docsearch.as_retriever(search_type="mmr", search_kwargs={"k": 5, "filter": filter})
+
+            # Answer question with RAG
+            qa_system_prompt = (
+            prompt_str +
+            "\n\n"
+            "{context}"
+            )
+
+            qa_prompt = ChatPromptTemplate.from_messages(
+                [
+                    ("system", qa_system_prompt),
+                    ("user", "{input}"),
+                ]
+            )
+            question_answer_chain = create_stuff_documents_chain(model, qa_prompt)
+            rag_chain = create_retrieval_chain(retriever, question_answer_chain)  
+            return rag_chain
+        except Exception as e:
+            print(f"Error loading FAISS index: {e}. Falling back to LLM-only approach.")
+            # Fall back to LLM-only approach
+
+    # LLM-only approach (no RAG)
+    direct_prompt = ChatPromptTemplate.from_messages(
         [
-            ("system", qa_system_prompt),
+            ("system", prompt_str),
             ("user", "{input}"),
         ]
     )
-    question_answer_chain = create_stuff_documents_chain(model, qa_prompt)
-
-    rag_chain = create_retrieval_chain(retriever, question_answer_chain)  
-
-    return rag_chain
+    
+    # Create a simple chain that just passes input to the LLM
+    direct_chain = direct_prompt | model
+    
+    # Wrap in a compatible interface
+    class LLMOnlyChain:
+        def __init__(self, chain):
+            self.chain = chain
+            
+        def invoke(self, input_text):
+            response = self.chain.invoke({"input": input_text})
+            return {"answer": response.content}
+    
+    return LLMOnlyChain(direct_chain)


### PR DESCRIPTION
This pull request introduces authentication setup, API key configuration, and significant updates to the application's logic, including fallback behavior for the `get_ragchain` function. The most important changes include adding configuration instructions for Auth0 and API keys, replacing deprecated Streamlit methods, and enhancing the retrieval-augmented generation (RAG) chain with a fallback to an LLM-only approach.

### Authentication and Configuration:

* Added a new "Configuration" section in the `README.md` with instructions for setting up Auth0 credentials in `secrets.toml` and API keys in `.env` for MistralAI and Hugging Face.
* Introduced example configuration files: `.env.example` for API keys and `secrets.toml` for Auth0 settings. [[1]](diffhunk://#diff-655c5aa7275b5f3a65c3490d42f074943df624b266aee6c85f1cac8e0e596a99R1-R2) [[2]](diffhunk://#diff-2483481c22b44a05d7c9ba2d7cd628d97604702e57436e8f0371a97701d1fddbR1-R9)

### Streamlit Authentication Updates:

* Updated src/mvt/app.py to replace deprecated st.experimental_user with st.user for authentication checks and user data handling, in accordance with Streamlit's deprecation notice effective May 11, 2025.[[1]](diffhunk://#diff-fa8c98156e87ebf5e26339b5e28ae168f89b28ac02ecf1eda5ac14c6de52593cL10-R10) [[2]](diffhunk://#diff-fa8c98156e87ebf5e26339b5e28ae168f89b28ac02ecf1eda5ac14c6de52593cL29-R44)

### Retrieval-Augmented Generation (RAG) Enhancements:

* Updated `get_ragchain` in `src/mvt/main.py` to include a fallback mechanism. If the FAISS index fails to load, the function now falls back to an LLM-only approach, ensuring robustness.
* Moved the definition of the LLM and prompt string earlier in the `get_ragchain` function for better readability and logical flow. [[1]](diffhunk://#diff-3e13efd154c6a846a49f9a87f3c6715b617c36ccdd3eba8b2af5cda2654d5aefL12-R27) [[2]](diffhunk://#diff-3e13efd154c6a846a49f9a87f3c6715b617c36ccdd3eba8b2af5cda2654d5aefL30-R37)

@gcapuzzi Could you please review this PR? I’d appreciate any suggestions or feedback you may have.