### PR TITLE
Add progress bar for document loading

### DIFF
--- a/src/mvt/ingest.py
+++ b/src/mvt/ingest.py
@@ -10,7 +10,7 @@ from langchain_text_splitters import RecursiveCharacterTextSplitter
 from langchain_community.document_loaders.recursive_url_loader import RecursiveUrlLoader
 from langchain_community.document_loaders.merge import MergedDataLoader
 from langchain_community.document_loaders import ReadTheDocsLoader
-
+from tqdm import tqdm
 
 
 # Read config data
@@ -28,8 +28,17 @@ loader_web = RecursiveUrlLoader(url=config_data["wiki_url"])
 # load documents from ReadTheDocs documentation
 loader_rtdocs = ReadTheDocsLoader(path="./rtdocs", encoding="utf-8", patterns=("*.html"))
 
+# change 2 -> progress bar
+
+class ProgressMergedDataLoader(MergedDataLoader):
+    def load(self):
+        docs = []
+        for loader in tqdm(self.loaders, desc="Loading documents"):
+            docs.extend(loader.load())
+        return docs
+
 # merge all the document sources
-loader= MergedDataLoader(loaders=[loader_rtdocs, loader_web])
+loader = ProgressMergedDataLoader(loaders=[loader_rtdocs, loader_web])
 
 # Load data
 docs = loader.load()

--- a/src/mvt/requirements.txt
+++ b/src/mvt/requirements.txt
@@ -11,3 +11,4 @@ beautifulsoup4
 transformers
 fastapi
 uvicorn
+tqdm>=4.66.0


### PR DESCRIPTION
 **Add progress bar for document loading**
- Added tqdm progress bar to MergedDataLoader
- Shows loading progress during document ingestion
- Updated requirements.txt with new dependency

 **Testing**
- Verified progress bar appears during both web and RTD doc loading
![Screenshot (250)](https://github.com/user-attachments/assets/7e8605ad-4560-4229-ad0a-360f4589b5a2)

**Next Step for Progress Bar**
 - Progress tracking for text splitting & Embedding generation & VectorDB storage status
 
### LFX Mentorship Interest

As an applicant for LFX Mentorship, I'm particularly interested in:
- Improving pipeline observability (starting with this progress bar)
- Enhancing RAG efficiency (crawling/retrieval optimization)
- Contributing to under-documented components

Would appreciate maintainers' guidance on where these skills could be most valuable!

