### PR TITLE
Fix typo in README.md for running frontend properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm install
 and then run:
 
 ```console
-npm run del
+npm run dev
 ```
 
 Now, open the web browser to http://localhost:3000 and type the question.


### PR DESCRIPTION
In the Installation Guidance of the project:

There was type : 
```
npm run del
```

Fix it with: 
```
npm run dev
```