### PR TITLE
Added instruction for setting up backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ to install the dependencies
 
 then create a **.env** ([MistralAI optaining the API key](https://console.mistral.ai/api-keys/)) file in the same directory that contains open ai key and add a row like this MISTRALAI_API_KEY = "mistralai_key"
 
-unzip file into rtdocs folder: it contains .html files.
+- unzip file into rtdocs folder: it contains .html files.
+- delete the rtdocs_files.zip.
 
 then run:
 


### PR DESCRIPTION
During the local setup of the project, I encountered difficulties while setting up the backend.

When I ran the command:

```bash
python ingest.py
```

I got the following error:

```
(lfdt) psyduck@fedora:~/opensource/aifaq/src/mvt$ python3 ingest.py 
Traceback (most recent call last):
  File "/home/psyduck/opensource/aifaq/src/mvt/ingest.py", line 35, in <module>
    docs = loader.load()
           ^^^^^^^^^^^^^
  File "/home/psyduck/anaconda3/envs/lfdt/lib/python3.12/site-packages/langchain_core/document_loaders/base.py", line 32, in load
    return list(self.lazy_load())
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/psyduck/anaconda3/envs/lfdt/lib/python3.12/site-packages/langchain_community/document_loaders/merge.py", line 23, in lazy_load
    for document in data:
                    ^^^^
  File "/home/psyduck/anaconda3/envs/lfdt/lib/python3.12/site-packages/langchain_community/document_loaders/readthedocs.py", line 84, in lazy_load
    text = self._clean_data(f.read())
                            ^^^^^^^^
  File "<frozen codecs>", line 322, in decode
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x90 in position 10: invalid start byte
```

After investigating, I discovered that the project expected only UTF-8 encoded files in the `/src/mvt/rtdocs/rtdocs_files` directory. However, the folder also contained a `rtdocs_files.zip` file, which caused the error.

Once I deleted the `rtdocs_files.zip` file, the script ran successfully:

```bash
python ingest.py
```

It thencreate a new folder named faiss_index containing the knowledge base (vector database):

![Screenshot From 2025-05-14 15-41-45](https://github.com/user-attachments/assets/3b1f0b8e-79d2-4f6b-9fea-e30bd86354f1)

