### PR TITLE
[Enhancement] Added support for dynamic 'k' value in config.yaml for retrieval

### DIFF
--- a/src/mvt/config.yaml
+++ b/src/mvt/config.yaml
@@ -16,3 +16,4 @@ system_prompt: "You are an assistant for question-answering tasks that are relat
 use_query_rewriting: false # Set to true to enable query rewriting
 query_rewriting_prompt: "You are an assistant helping to rewrite user queries to make them more specific and effective for searching documents. The context is the Linux Foundation Decentralized Trust former Hyperledger. Please rewrite the human query to be more specific, detailed, and optimized for document retrieval, considering the context mentioned."
 logo_pth: "https://upload.wikimedia.org/wikipedia/en/thumb/e/e2/The_Founder_Institute_Logo.png/250px-The_Founder_Institute_Logo.png"
+k: 5

--- a/src/mvt/main.py
+++ b/src/mvt/main.py
@@ -47,7 +47,7 @@ def get_ragchain(filter):
     docsearch = FAISS.load_local(config_data["persist_directory"], embeddings, allow_dangerous_deserialization=True)
 
     # Define a retriever interface
-    retriever = docsearch.as_retriever(search_kwargs={"k": 5, "filter": filter})
+    retriever = docsearch.as_retriever(search_kwargs={"k": config_data["k"], "filter": filter})
 
     # read prompt string from config file
     prompt_str = config_data["system_prompt"]


### PR DESCRIPTION

Previously, the number of retrieved documents from the vector database was hardcoded. Now, I have added k: 5 in config.yaml to dynamically control the number of documents retrieved and replace the hard-coded value with dynamic value of `k`.


![image](https://github.com/user-attachments/assets/fcab4e3d-676a-44f1-af09-337b8b166ffc)
