### PR TITLE
[bugfix] unterminated triple-quoted string in database.py

### DIFF
--- a/src/mvt/database.py
+++ b/src/mvt/database.py
@@ -135,7 +135,12 @@ def create_feedback_table(conn):
                     response_snippet TEXT,
                     reason TEXT,
                     timestamp TEXT
-# ==================== ADDITIONAL FUNCTIONS FOR OTHER TABLES ====================
+                );'''
+        # ==================== ADDITIONAL FUNCTIONS FOR OTHER TABLES ====================
+        conn.cursor().execute(sql)
+        conn.commit()
+    except sqlite3.Error as e:
+        print(e)
 
 def create_response_table(conn):
     """Create a table to store responses"""


### PR DESCRIPTION
fixed a bug where a sql string in create_feedback_table was not properly closed, causing a syntax error and breaking the app